### PR TITLE
Apparently the module needed is inside the module with the same name

### DIFF
--- a/UserList/plugin.py
+++ b/UserList/plugin.py
@@ -7,7 +7,7 @@ from typing import List
 from xml.dom.minidom import getDOMImplementation, Document
 #JSON Generation:
 import json
-import datetime
+from datetime import datetime
 #timezone:
 import tzlocal
 


### PR DESCRIPTION
Now, it's not crashing on call. I haven't investigated if the code uses the `datetime` module as is elsewhere in the code, i think a review at it is needed as well, otherwise, i think we could instead of change the `import`, use it in code as `datetime.datetime.now()` which is of equivalent nature.