### PR TITLE
SpiffyTitles: add redundant title suppression

### DIFF
--- a/SpiffyTitles/config.py
+++ b/SpiffyTitles/config.py
@@ -41,6 +41,18 @@ except:
     _ = lambda x: x
 
 
+class _UnitFloat(registry.Float):
+    """Value must be a floating-point number between 0.0 and 1.0."""
+    errormsg = _(
+        "Value must be a floating-point number between 0.0 and 1.0, not %r."
+    )
+
+    def setValue(self, v):
+        if not (0.0 <= float(v) <= 1.0):
+            self.error(v)
+        super(_UnitFloat, self).setValue(v)
+
+
 def configure(advanced):
     # This will be called by supybot to configure this module.  advanced is
     # a bool that specifies whether the user identified themself as an advanced
@@ -718,7 +730,7 @@ conf.registerChannelValue(
 conf.registerChannelValue(
     SpiffyTitles,
     "redundantTitleThreshold",
-    registry.Float(
+    _UnitFloat(
         0.0,
         _("""Suppress title output when this fraction (0.0-1.0) of the
         meaningful tokens in the URL slug are found in the title. 0.0

--- a/SpiffyTitles/config.py
+++ b/SpiffyTitles/config.py
@@ -713,3 +713,16 @@ conf.registerChannelValue(
         _("""Uses Twitter API to get additional information about twitter.com links"""),
     ),
 )
+
+# Redundant title suppression
+conf.registerChannelValue(
+    SpiffyTitles,
+    "redundantTitleThreshold",
+    registry.Float(
+        0.0,
+        _("""Suppress title output when this fraction (0.0-1.0) of the
+        meaningful tokens in the URL slug are found in the title. 0.0
+        disables the check. Can be set globally or overridden per-channel
+        with 'config channel #foo SpiffyTitles.redundantTitleThreshold'."""),
+    ),
+)

--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -65,6 +65,77 @@ except ImportError:
     _ = lambda x: x
 
 
+def _slug_title_coverage(url, title):
+    """
+    Compute the redundancy coverage ratio between a URL slug and a title.
+
+    Returns a float in [0.0, 1.0] representing the fraction of meaningful
+    slug tokens (length > 2) that appear in the normalised title token set.
+    Returns None when the slug yields no meaningful tokens (e.g. bare
+    domain, numeric-only path) so callers can distinguish "no signal" from
+    "zero match".
+
+    Normalisation pipeline (applied identically to slug and title):
+    - NFKD Unicode decomposition, drop combining characters (strips all
+      Latin-based diacritics: Romanian, French, Spanish, etc.)
+    - Lowercase
+    - Replace hyphens, en/em-dashes, and slashes with spaces
+    - Strip every character that is not an ASCII letter, digit, or space
+    - Split into a token set
+    """
+    # --- 1. Extract slug ------------------------------------------------
+    path = urlparse(url).path
+    segments = [s for s in path.split("/") if s]
+    if not segments:
+        return None
+    slug = segments[-1]
+    # Strip common file extensions
+    slug = re.sub(r'\.[a-zA-Z0-9]{1,5}$', '', slug)
+    # Strip trailing numeric ID (dash followed by 4+ digits at the end)
+    slug = re.sub(r'-\d{4,}$', '', slug)
+
+    # --- 2. Normalise pipeline ------------------------------------------
+    def _normalise(text):
+        nfkd = unicodedata.normalize("NFKD", text)
+        ascii_only = "".join(
+            c for c in nfkd if unicodedata.category(c) != "Mn"
+        )
+        lowered = ascii_only.lower()
+        # Replace hyphens, en-dash (U+2013), em-dash (U+2014), and
+        # forward/back slashes with spaces
+        spaced = re.sub(r'[-\u2013\u2014/\\]', ' ', lowered)
+        # Keep only ASCII letters, digits, and spaces
+        cleaned = re.sub(r'[^a-z0-9 ]', '', spaced)
+        return set(cleaned.split())
+
+    slug_tokens = _normalise(slug)
+    title_tokens = _normalise(title)
+
+    # --- 3. Meaningful slug tokens (length > 2) -------------------------
+    meaningful = {t for t in slug_tokens if len(t) > 2}
+    if not meaningful:
+        return None
+
+    # --- 4. Coverage ----------------------------------------------------
+    return len(meaningful & title_tokens) / len(meaningful)
+
+
+def is_title_redundant(url, title, threshold=0.6):
+    """
+    Return True when the article title is redundant given the URL slug.
+
+    Delegates coverage computation to _slug_title_coverage() and compares
+    against threshold.  Returns False when threshold is 0 or when the slug
+    yields no meaningful tokens.
+    """
+    if not threshold:
+        return False
+    coverage = _slug_title_coverage(url, title)
+    if coverage is None:
+        return False
+    return coverage >= threshold
+
+
 class SpiffyTitles(callbacks.Plugin):
     """Displays link titles when posted in a channel"""
 
@@ -243,7 +314,31 @@ class SpiffyTitles(callbacks.Plugin):
                     ignore_match = self.title_matches_ignore_pattern(title, channel, irc.network)
                     if ignore_match:
                         return
-                    elif not is_ignored:
+                    redundant_threshold = self.registryValue(
+                        "redundantTitleThreshold",
+                        channel=channel,
+                        network=irc.network,
+                    )
+                    if redundant_threshold > 0.0:
+                        coverage = _slug_title_coverage(url, title)
+                        redundant = (
+                            coverage is not None
+                            and coverage >= redundant_threshold
+                        )
+                        log.info(
+                            "SpiffyTitles: redundancy check for %s"
+                            " — coverage=%.2f %s threshold=%.2f — %s"
+                            % (
+                                url,
+                                coverage if coverage is not None else 0.0,
+                                ">=" if redundant else "<",
+                                redundant_threshold,
+                                "suppressed" if redundant else "passed",
+                            )
+                        )
+                        if redundant:
+                            return
+                    if not is_ignored:
                         irc.reply(title, prefixNick=prefixed)
                 else:
                     if self.registryValue("default.enabled", channel, network=irc.network):

--- a/SpiffyTitles/plugin.py
+++ b/SpiffyTitles/plugin.py
@@ -321,23 +321,30 @@ class SpiffyTitles(callbacks.Plugin):
                     )
                     if redundant_threshold > 0.0:
                         coverage = _slug_title_coverage(url, title)
-                        redundant = (
-                            coverage is not None
-                            and coverage >= redundant_threshold
-                        )
-                        log.info(
-                            "SpiffyTitles: redundancy check for %s"
-                            " — coverage=%.2f %s threshold=%.2f — %s"
-                            % (
-                                url,
-                                coverage if coverage is not None else 0.0,
-                                ">=" if redundant else "<",
-                                redundant_threshold,
-                                "suppressed" if redundant else "passed",
+                        if coverage is None:
+                            log.info(
+                                "SpiffyTitles: redundancy check for %s"
+                                " — coverage=n/a threshold=%.2f"
+                                " — passed (no slug signal)"
+                                % (url, redundant_threshold)
                             )
-                        )
-                        if redundant:
-                            return
+                        else:
+                            redundant = is_title_redundant(
+                                url, title, redundant_threshold
+                            )
+                            log.info(
+                                "SpiffyTitles: redundancy check for %s"
+                                " — coverage=%.2f %s threshold=%.2f — %s"
+                                % (
+                                    url,
+                                    coverage,
+                                    ">=" if redundant else "<",
+                                    redundant_threshold,
+                                    "suppressed" if redundant else "passed",
+                                )
+                            )
+                            if redundant:
+                                return
                     if not is_ignored:
                         irc.reply(title, prefixNick=prefixed)
                 else:


### PR DESCRIPTION
Adds a configurable option to suppress title output when the URL slug already conveys the same information as the fetched title, avoiding noise like:

> [user posts link] https://some-site.com/articles/how-to-configure-nginx  
> [bot replies] How to Configure Nginx

# Changes

New config value: `supybot.plugins.SpiffyTitles.redundantTitleThreshold` (float, default 0.0)
- 0.0: feature disabled (default, no behavior change)
- 0.1–1.0: suppress the title when this fraction of meaningful slug tokens appear in the title

Can be set globally or overridden per-channel:

> config supybot.plugins.SpiffyTitles.redundantTitleThreshold 0.6
> config channel #foo supybot.plugins.SpiffyTitles.redundantTitleThreshold 0.8

From *personal* experience, `0.6` will suppress the most noise. 

# How it works

A normalization pipeline is applied to both the URL slug and the fetched title:

- NFKD Unicode decomposition (strips Latin diacritics)
- Lowercase, strip punctuation, split into tokens
- Trailing numeric IDs and file extensions are stripped from the slug

The coverage ratio (matching tokens / total meaningful slug tokens) is compared against the threshold. If met or exceeded, the title is silently suppressed. A log line is emitted either way for debugging.
The check is skipped entirely when the slug yields no meaningful tokens (bare domains, numeric-only paths, etc.), so false positives on short or opaque URLs are avoided.